### PR TITLE
Add html id's to ok and cancel button

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
@@ -392,8 +392,8 @@ window.RecurringSelectDialog =
               <span></span>
             </p>
             <div class='controls'>
-              <input type='button' data-wrapper-class='ui-recurring-select' class='rs_save' value='#{$.fn.recurring_select.texts["ok"]}' />
-              <input type='button' data-wrapper-class='ui-recurring-select' class='rs_cancel' value='#{$.fn.recurring_select.texts["cancel"]}' />
+              <input type='button' data-wrapper-class='ui-recurring-select' id='rs_save' class='rs_save' value='#{$.fn.recurring_select.texts["ok"]}' />
+              <input type='button' data-wrapper-class='ui-recurring-select' id='rs_cancel' class='rs_cancel' value='#{$.fn.recurring_select.texts["cancel"]}' />
             </div>
           </div>
         </div>


### PR DESCRIPTION
While developing a Rails application, Rspec/Capybara did not accept the Html class or other capybara options. 
I tried:
- `click_on '.rs_save'`
- `find('.rs_save').click`
- `execute_script("document.querySelector('.rs_save').click()")`
All of the above would randomly fail.
Adding an Html id may fix the issue. 